### PR TITLE
Refactor single page layouts

### DIFF
--- a/layouts/partials/misc/repotags.html
+++ b/layouts/partials/misc/repotags.html
@@ -1,8 +1,1 @@
-<div class="tags">
-  <ul style="padding-left: 0;">
-    {{ range . }}
-    {{ $url:= printf "repo-tags/%s/" . }}
-    <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn btn-sm btn-info">{{ . }}</a></li>
-    {{ end }}
-  </ul>
-</div>
+{{ partial "misc/tags.html" (dict "tags" . "prefix" "repo-tags") }}

--- a/layouts/partials/misc/startags.html
+++ b/layouts/partials/misc/startags.html
@@ -1,8 +1,1 @@
-<div class="tags">
-  <ul style="padding-left: 0;">
-    {{ range . }}
-    {{ $url:= printf "star-tags/%s/" . }}
-    <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn btn-sm btn-info">{{ . }}</a></li>
-    {{ end }}
-  </ul>
-</div>
+{{ partial "misc/tags.html" (dict "tags" . "prefix" "star-tags") }}

--- a/layouts/partials/misc/tags.html
+++ b/layouts/partials/misc/tags.html
@@ -1,0 +1,8 @@
+<div class="tags">
+  <ul style="padding-left: 0;">
+    {{ range .tags }}
+    {{ $url := printf "%s/%s/" $.prefix . }}
+    <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn btn-sm btn-info">{{ . }}</a></li>
+    {{ end }}
+  </ul>
+</div>

--- a/layouts/partials/navigators/repo-taxonomies.html
+++ b/layouts/partials/navigators/repo-taxonomies.html
@@ -1,16 +1,1 @@
-{{ $context := .context  }}
-{{ $taxo := .taxo  }}
-{{ $class:= "" }}
-{{ if isset $context.Site.Taxonomies ( lower $taxo ) }}
-  {{ $taxonomy := index $context.Site.Taxonomies ( lower $taxo ) }}
-  {{ if (gt (len $taxonomy) 0)}}
-        {{ range $taxonomy }}
-          {{if eq $context.Title .Page.Title}}
-            {{ $class = "active" }}
-          {{else}}
-            {{$class = ""}}
-          {{end}}
-          <li><a class="taxonomy-term {{ $class }}" href="{{ .Page.Permalink }}" data-taxonomy-term="{{ urlize .Page.Title }}"><span class="taxonomy-label">{{ .Page.Title }}</span></a></li>
-        {{ end }}
-  {{ end }}
-{{ end }}
+{{ partial "navigators/taxonomies.html" . }}

--- a/layouts/partials/navigators/star-taxonomies.html
+++ b/layouts/partials/navigators/star-taxonomies.html
@@ -1,16 +1,1 @@
-{{ $context := .context  }}
-{{ $taxo := .taxo  }}
-{{ $class:= "" }}
-{{ if isset $context.Site.Taxonomies ( lower $taxo ) }}
-  {{ $taxonomy := index $context.Site.Taxonomies ( lower $taxo ) }}
-  {{ if (gt (len $taxonomy) 0)}}
-        {{ range $taxonomy }}
-          {{if eq $context.Title .Page.Title}}
-            {{ $class = "active" }}
-          {{else}}
-            {{$class = ""}}
-          {{end}}
-          <li><a class="taxonomy-term {{ $class }}" href="{{ .Page.Permalink }}" data-taxonomy-term="{{ urlize .Page.Title }}"><span class="taxonomy-label">{{ .Page.Title }}</span></a></li>
-        {{ end }}
-  {{ end }}
-{{ end }}
+{{ partial "navigators/taxonomies.html" . }}

--- a/layouts/partials/navigators/taxonomies.html
+++ b/layouts/partials/navigators/taxonomies.html
@@ -1,0 +1,16 @@
+{{ $context := .context }}
+{{ $taxo := .taxo }}
+{{ $class := "" }}
+{{ if isset $context.Site.Taxonomies ( lower $taxo ) }}
+  {{ $taxonomy := index $context.Site.Taxonomies ( lower $taxo ) }}
+  {{ if (gt (len $taxonomy) 0) }}
+        {{ range $taxonomy }}
+          {{ if eq $context.Title .Page.Title }}
+            {{ $class = "active" }}
+          {{ else }}
+            {{ $class = "" }}
+          {{ end }}
+          <li><a class="taxonomy-term {{ $class }}" href="{{ .Page.Permalink }}" data-taxonomy-term="{{ urlize .Page.Title }}"><span class="taxonomy-label">{{ .Page.Title }}</span></a></li>
+        {{ end }}
+  {{ end }}
+{{ end }}

--- a/layouts/partials/single/content.html
+++ b/layouts/partials/single/content.html
@@ -1,0 +1,146 @@
+{{ $ctx := .context }}
+{{ $taxo := .taxo }}
+<section class="content-section" id="content-section">
+    <div class="content">
+        <div class="container p-0 read-area">
+            <!--Hero Area-->
+            <div class="hero-area col-sm-12" id="hero-area" style='background-image: url({{ $ctx.Params.heroUrl }});'>
+            </div>
+
+            <!--Content Start-->
+            <div class="page-content">
+                {{ if site.Params.features.blog.showAuthor | default true }}
+                <div class="author-profile ms-auto align-self-lg-center">
+                    <a href="{{ $ctx.Params.owner.html_url}}"><img class="rounded-circle" src='{{ $ctx.Params.owner.avatar_url }}' alt="Author Image"></a>
+                    <h5 class="author-name"><a href="{{ $ctx.Params.owner.html_url}}">{{ $ctx.Params.owner.login }}</a></h5>
+                    <p class="text-muted">{{ $ctx.Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ $ctx.ReadingTime }} {{i18n "minute" $ctx.ReadingTime }}{{ end }}</p>
+                </div>
+                {{ else }}
+                <div style="margin-bottom: 80px;"></div>
+                {{ end }}
+
+                <div class="title">
+                    <h1><a href="{{ $ctx.Params.html_url}}">{{ $ctx.Page.Title }}</a></h1>
+                    {{ if $ctx.Params.fork }} Forked {{ end }}
+                    {{ if $ctx.Params.archived }} Archived {{ end }}
+                </div>
+
+                {{ if not (site.Params.features.blog.showAuthor | default true) }}
+                <div class="author-profile ms-auto align-self-lg-center">
+                    <p class="text-muted">{{ $ctx.Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ $ctx.ReadingTime }} {{i18n "minute" $ctx.ReadingTime }}{{ end }}</p>
+                </div>
+                {{ end }}
+
+                {{ if site.Params.features.tags.enable }}
+                {{ partial "misc/tags.html" (dict "tags" (index $ctx.Params $taxo) "prefix" $taxo) }}
+                {{ end }}
+                <div class="post-content" id="post-content">
+                    {{ $ctx.Page.Content }}
+                </div>
+
+                <!-- Share or Contribute -->
+                <div class="row ps-3 pe-3">
+                    <!--Social Media Share Buttons-->
+                    <div class="col-md-6 share-buttons">
+                        {{ if site.Params.features.blog.shareButtons }}
+                        <strong>{{ i18n "share_on" }}:</strong>
+                        {{ if site.Params.features.blog.shareButtons.facebook }}
+                        <a class="btn icon-button bg-facebook" href="https://www.facebook.com/sharer.php?u={{ $ctx.Permalink }}" target="_blank">
+                            <i class="fab fa-facebook"></i>
+                        </a>
+                        {{ end }}
+                        {{ if site.Params.features.blog.shareButtons.twitter }}
+                        <a class="btn icon-button bg-twitter" href="https://twitter.com/share?url={{ $ctx.Permalink }}&text={{ $ctx.Title }}&via={{- site.Title -}}" target="_blank">
+                            <i class="fab fa-twitter"></i>
+                        </a>
+                        {{ end }}
+                        {{ if site.Params.features.blog.shareButtons.reddit }}
+                        <a  class="btn icon-button bg-reddit" href="https://reddit.com/submit?url={{ $ctx.Permalink }}&title={{ $ctx.Title }}" target="_blank">
+                            <i class="fab fa-reddit"></i>
+                        </a>
+                        {{ end }}
+                        {{ if site.Params.features.blog.shareButtons.tumblr }}
+                        <a class="btn icon-button bg-tumblr" href="https://www.tumblr.com/share/link?url={{ $ctx.Permalink }}&name={{ $ctx.Title }}{{- with $ctx.Params.description -}}&description={{- . -}}{{- end -}}" target="_blank">
+                            <i class="fab fa-tumblr"></i>
+                        </a>
+                        {{ end }}
+                        {{ if site.Params.features.blog.shareButtons.pocket }}
+                        <a class="btn icon-button bg-pocket" href="https://getpocket.com/save?url={{ $ctx.Permalink }}&title={{ $ctx.Title }}" target="_blank">
+                            <i class="fab fa-get-pocket"></i>
+                        </a>
+                        {{ end }}
+                        {{ if site.Params.features.blog.shareButtons.linkedin }}
+                        <a class="btn icon-button bg-linkedin" href="https://www.linkedin.com/shareArticle?url={{ $ctx.Permalink }}&title={{ $ctx.Title }}" target="_blank">
+                            <i class="fab fa-linkedin"></i>
+                        </a>
+                        {{ end }}
+                        {{ if site.Params.features.blog.shareButtons.diaspora }}
+                        <a class="btn icon-button bg-diaspora" href="https://share.diasporafoundation.org/?title={{ $ctx.Title }}&url={{ $ctx.Permalink }}" rel="nofollow" target="_blank">
+                            <i class="fab fa-diaspora"></i>
+                        </a>
+                        {{ end }}
+                        {{ if site.Params.features.blog.shareButtons.mastodon }}
+                        <a class="btn icon-button bg-mastodon" href="https://mastodon.social/share?text={{ $ctx.Title }} - {{ $ctx.Permalink }}" target="_blank">
+                            <i class="fab fa-mastodon"></i>
+                        </a>
+                        {{ end }}
+                        {{ if site.Params.features.blog.shareButtons.whatsapp }}
+                        <a class="btn icon-button bg-whatsapp" href="https://api.whatsapp.com/send?text={{ $ctx.Title }} {{ $ctx.Permalink }}" target="_blank">
+                            <i class="fab fa-whatsapp"></i>
+                        </a>
+                        {{ end }}
+                        {{ if site.Params.features.blog.shareButtons.email }}
+                        <a class="btn icon-button" href="mailto:?subject={{ $ctx.Title }}&body={{ $ctx.Permalink }}" target="_blank">
+                            <i class="fas fa-envelope-open-text"></i>
+                        </a>
+                        {{ end }}
+                        {{ end }}
+                    </div>
+
+                    <!--- Improve this page button --->
+                    {{ if site.Params.GitRepo }}
+                    {{ if site.Params.GitBranch }}
+                    {{ $ctx.Scratch.Set "GitBranch" site.Params.GitBranch }}
+                    {{ else }}
+                    {{ $ctx.Scratch.Set "GitBranch" "main" }}
+                    {{ end }}
+                    <div class="col-md-6 btn-improve-page">
+                        {{ if ( eq site.Params.GitForge "gitlab" ) }}
+                        <a href="{{ site.Params.GitRepo }}/-/edit/{{ $ctx.Scratch.Get "GitBranch" }}/content/{{ $ctx.File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
+                        {{ else if ( eq site.Params.GitForge "gitea" ) }}
+                        <a href="{{ site.Params.GitRepo }}/_edit/{{ $ctx.Scratch.Get "GitBranch" }}/content/{{ $ctx.File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
+                        {{ else }} <!--- Make Github-style the default -->
+                        <a href="{{ site.Params.GitRepo }}/edit/{{ $ctx.Scratch.Get "GitBranch" }}/content/{{ $ctx.File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
+                        {{ end }}
+                        <i class="fas fa-code-branch"></i>
+                        {{ i18n "improve_this_page" }}
+                        </a>
+                    </div>
+                    {{ end }}
+                </div>
+
+
+
+                <!---Next and Previous Navigator -->
+                <hr />
+                {{ partial "navigators/next-prev-navigator.html" $ctx }}
+                <hr />
+
+                <!----- Add comment support  ----->
+                {{ if site.Params.features.comment.enable }}
+                {{ partial "comments.html" site.Params.features.comment.services }}
+                {{ end }}
+
+                <!-- Keep backward compatibility with old config.yaml -->
+                {{ if $ctx.Site.Config.Services.Disqus.Shortname }}
+                {{ partial "comments/disqus.html" (dict (slice "disqus" "shortName")  $ctx.Site.Config.Services.Disqus.Shortname) }}
+                {{ end }}
+
+            </div>
+        </div>
+    </div>
+    <!--scroll back to top-->
+    <a id="scroll-to-top" class="btn" type="button" data-bs-toggle="tooltip" data-bs-placement="left" title="Scroll to top">
+        <i class="fas fa-chevron-circle-up"></i>
+    </a>
+</section>

--- a/layouts/partials/single/header.html
+++ b/layouts/partials/single/header.html
@@ -1,0 +1,1 @@
+<meta name="description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Title }}{{ end }}" />

--- a/layouts/partials/single/sidebar.html
+++ b/layouts/partials/single/sidebar.html
@@ -1,0 +1,24 @@
+{{ $ctx := .context }}
+{{ $taxo := .taxo }}
+<section class="sidebar-section" id="sidebar-section">
+    <div class="sidebar-holder">
+        <div class="sidebar" id="sidebar">
+            <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
+            <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
+            </form>
+            <div class="sidebar-tree">
+                <ul class="tree">
+                    <li style="padding-left: 0px !important;"><a href="{{ $ctx.Type | relLangURL }}" data-filter="all">{{ i18n $ctx.Type }}</a></li>
+                </ul>
+            </div>
+            <div class="sidebar-tree">
+                <ul class="tree" id="tree">
+                    <li id="list-heading">{{ i18n $taxo }}</li>
+                    <div class="subtree">
+                        {{ partial "navigators/taxonomies.html" (dict "context" $ctx "taxo" $taxo "title" (humanize "tags")) }}
+                    </div>
+                </ul>
+            </div>
+        </div>
+    </div>
+</section>

--- a/layouts/partials/single/toc.html
+++ b/layouts/partials/single/toc.html
@@ -1,0 +1,11 @@
+<section class="toc-section" id="toc-section">
+    {{ if and site.Params.features.toc.enable ( .Params.enableTOC | default true ) }}
+    <div class="toc-holder">
+        <h5 class="text-center ps-3">{{ i18n "toc_heading" }}</h5>
+        <hr>
+        <div class="toc">
+            {{ .TableOfContents }}
+        </div>
+    </div>
+    {{ end }}
+</section>

--- a/layouts/repo-tags/list.html
+++ b/layouts/repo-tags/list.html
@@ -24,7 +24,7 @@
             <li id="list-heading">{{ i18n .Type }}</li>
             <div class="subtree taxonomy-terms">
               {{ $context := . }}
-              {{ partial "navigators/repo-taxonomies.html" (dict "context" $context "taxo" "repo-tags" "title" ( humanize "repos" ) ) }}
+              {{ partial "navigators/taxonomies.html" (dict "context" $context "taxo" "repo-tags" "title" ( humanize "repos" ) ) }}
             </div>
           </ul>
         </div>

--- a/layouts/repos/list.html
+++ b/layouts/repos/list.html
@@ -23,7 +23,7 @@
           <ul class="tree" id="tree">
             <li id="list-heading">{{ i18n "repo-tags" }}</li>
             <div class="subtree">
-                {{ partial "navigators/repo-taxonomies.html" (dict "context" . "taxo" "repo-tags" "title" ( humanize "tags" ) ) }}
+                {{ partial "navigators/taxonomies.html" (dict "context" . "taxo" "repo-tags" "title" ( humanize "tags" ) ) }}
             </div>
           </ul>
         </div>

--- a/layouts/repos/single.html
+++ b/layouts/repos/single.html
@@ -1,5 +1,5 @@
 {{ define "header" }}
-<meta name="description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Title }}{{ end }}" />
+{{ partial "single/header.html" . }}
 {{ end }}
 
 {{ define "navbar" }}
@@ -7,187 +7,13 @@
 {{ end }}
 
 {{ define "sidebar" }}
-<section class="sidebar-section" id="sidebar-section">
-    <div class="sidebar-holder">
-        <div class="sidebar" id="sidebar">
-            <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
-            <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
-            </form>
-            <div class="sidebar-tree">
-                <ul class="tree">
-                    <li style="padding-left: 0px !important;"><a href="{{ .Type | relLangURL }}" data-filter="all">{{ i18n .Type }}</a></li>
-                </ul>
-            </div>
-            <div class="sidebar-tree">
-                <ul class="tree" id="tree">
-                    <li id="list-heading">{{ i18n "repo-tags" }}</li>
-                    <div class="subtree">
-                        {{ partial "navigators/repo-taxonomies.html" (dict "context" . "taxo" "repo-tags" "title" ( humanize "tags" ) ) }}
-                    </div>
-                </ul>
-            </div>
-        </div>
-    </div>
-</section>
+{{ partial "single/sidebar.html" (dict "context" . "taxo" "repo-tags") }}
 {{ end }}
 
 {{ define "content" }}
-<section class="content-section" id="content-section">
-    <div class="content">
-        <div class="container p-0 read-area">
-            <!--Hero Area-->
-            <div class="hero-area col-sm-12" id="hero-area" style='background-image: url({{ .Params.heroUrl }});'>
-            </div>
-
-            <!--Content Repot-->
-            <div class="page-content">
-                {{ if site.Params.features.blog.showAuthor | default true }}
-                <div class="author-profile ms-auto align-self-lg-center">
-                    <a href="{{ .Params.owner.html_url}}"><img class="rounded-circle" src='{{ .Params.owner.avatar_url }}' alt="Author Image"></a>
-                    <h5 class="author-name"><a href="{{ .Params.owner.html_url}}">{{ .Params.owner.login }}</a></h5>
-                    <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
-                </div>
-                {{ else }}
-                <div style="margin-bottom: 80px;"></div>
-                {{ end }}
-
-                <div class="title">
-                    <h1><a href="{{ .Params.html_url}}">{{ .Page.Title }}</a></h1>
-                    {{ if .Params.fork }} Forked {{ end }}
-                    {{ if .Params.archived }} Archived {{ end }}
-                </div>
-
-                {{ if not (site.Params.features.blog.showAuthor | default true) }}
-                <div class="author-profile ms-auto align-self-lg-center">
-                    <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
-                </div>
-                {{ end }}
-
-                {{ if site.Params.features.tags.enable }}
-                {{partial "misc/repotags.html" (index .Params "repo-tags" ) }}
-                {{ end }}
-                <div class="post-content" id="post-content">
-                    {{ .Page.Content }}
-                </div>
-
-                <!-- Share or Contribute -->
-                <div class="row ps-3 pe-3">
-                    <!--Social Media Share Buttons-->
-                    <div class="col-md-6 share-buttons">
-                        {{ if site.Params.features.blog.shareButtons }}
-                        <strong>{{ i18n "share_on" }}:</strong>
-                        {{ if site.Params.features.blog.shareButtons.facebook }}
-                        <a class="btn icon-button bg-facebook" href="https://www.facebook.com/sharer.php?u={{ .Permalink }}" target="_blank">
-                            <i class="fab fa-facebook"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.twitter }}
-                        <a class="btn icon-button bg-twitter" href="https://twitter.com/share?url={{ .Permalink }}&text={{ .Title }}&via={{- site.Title -}}" target="_blank">
-                            <i class="fab fa-twitter"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.reddit }}
-                        <a  class="btn icon-button bg-reddit" href="https://reddit.com/submit?url={{ .Permalink }}&title={{ .Title }}" target="_blank">
-                            <i class="fab fa-reddit"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.tumblr }}
-                        <a class="btn icon-button bg-tumblr" href="https://www.tumblr.com/share/link?url={{ .Permalink }}&name={{ .Title }}{{- with .Params.description -}}&description={{- . -}}{{- end -}}" target="_blank">
-                            <i class="fab fa-tumblr"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.pocket }}
-                        <a class="btn icon-button bg-pocket" href="https://getpocket.com/save?url={{ .Permalink }}&title={{ .Title }}" target="_blank">
-                            <i class="fab fa-get-pocket"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.linkedin }}
-                        <a class="btn icon-button bg-linkedin" href="https://www.linkedin.com/shareArticle?url={{ .Permalink }}&title={{ .Title }}" target="_blank">
-                            <i class="fab fa-linkedin"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.diaspora }}
-                        <a class="btn icon-button bg-diaspora" href="https://share.diasporafoundation.org/?title={{ .Title }}&url={{ .Permalink }}" rel="nofollow" target="_blank">
-                            <i class="fab fa-diaspora"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.mastodon }}
-                        <a class="btn icon-button bg-mastodon" href="https://mastodon.social/share?text={{ .Title }} - {{ .Permalink }}" target="_blank">
-                            <i class="fab fa-mastodon"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.whatsapp }}
-                        <a class="btn icon-button bg-whatsapp" href="https://api.whatsapp.com/send?text={{ .Title }} {{ .Permalink }}" target="_blank">
-                            <i class="fab fa-whatsapp"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.email }}
-                        <a class="btn icon-button" href="mailto:?subject={{ .Title }}&body={{ .Permalink }}" target="_blank">
-                            <i class="fas fa-envelope-open-text"></i>
-                        </a>
-                        {{ end }}
-                        {{ end }}
-                    </div>
-
-                    <!--- Improve this page button --->
-                    {{ if site.Params.GitRepo }}
-                    {{ if site.Params.GitBranch }}
-                    {{ .Scratch.Set "GitBranch" site.Params.GitBranch }}
-                    {{ else }}
-                    {{ .Scratch.Set "GitBranch" "main" }}
-                    {{ end }}
-                    <div class="col-md-6 btn-improve-page">
-                        {{ if ( eq site.Params.GitForge "gitlab" ) }}
-                        <a href="{{ site.Params.GitRepo }}/-/edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
-                        {{ else if ( eq site.Params.GitForge "gitea" ) }}
-                        <a href="{{ site.Params.GitRepo }}/_edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
-                        {{ else }} <!--- Make Github-style the default -->
-                        <a href="{{ site.Params.GitRepo }}/edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
-                        {{ end }}
-                        <i class="fas fa-code-branch"></i>
-                        {{ i18n "improve_this_page" }}
-                        </a>
-                    </div>
-                    {{ end }}
-                </div>
-
-
-
-                <!---Next and Previous Navigator -->
-                <hr />
-                {{ partial "navigators/next-prev-navigator.html" . }}
-                <hr />
-
-                <!----- Add comment support  ----->
-                {{ if site.Params.features.comment.enable }}
-                {{ partial "comments.html" site.Params.features.comment.services }}
-                {{ end }}
-
-                <!-- Keep backward compatibility with old config.yaml -->
-                {{ if .Site.Config.Services.Disqus.Shortname }}
-                {{ partial "comments/disqus.html" (dict (slice "disqus" "shortName")  .Site.Config.Services.Disqus.Shortname) }}
-                {{ end }}
-
-            </div>
-        </div>
-    </div>
-    <!--scroll back to top-->
-    <a id="scroll-to-top" class="btn" type="button" data-bs-toggle="tooltip" data-bs-placement="left" title="Scroll to top">
-        <i class="fas fa-chevron-circle-up"></i>
-    </a>
-</section>
+{{ partial "single/content.html" (dict "context" . "taxo" "repo-tags") }}
 {{ end }}
 
 {{ define "toc" }}
-<section class="toc-section" id="toc-section">
-    {{ if and site.Params.features.toc.enable ( .Params.enableTOC | default true ) }}
-    <div class="toc-holder">
-        <h5 class="text-center ps-3">{{ i18n "toc_heading" }}</h5>
-        <hr>
-        <div class="toc">
-            {{ .TableOfContents }}
-        </div>
-    </div>
-    {{ end }}
-</section>
+{{ partial "single/toc.html" . }}
 {{ end }}

--- a/layouts/star-tags/list.html
+++ b/layouts/star-tags/list.html
@@ -24,7 +24,7 @@
             <li id="list-heading">{{ i18n .Type }}</li>
             <div class="subtree taxonomy-terms">
               {{ $context := . }}
-              {{ partial "navigators/star-taxonomies.html" (dict "context" $context "taxo" "star-tags" "title" ( humanize "stars" ) ) }}
+              {{ partial "navigators/taxonomies.html" (dict "context" $context "taxo" "star-tags" "title" ( humanize "stars" ) ) }}
             </div>
           </ul>
         </div>

--- a/layouts/stars/list.html
+++ b/layouts/stars/list.html
@@ -23,7 +23,7 @@
           <ul class="tree" id="tree">
             <li id="list-heading">{{ i18n "star-tags" }}</li>
             <div class="subtree">
-                {{ partial "navigators/star-taxonomies.html" (dict "context" . "taxo" "star-tags" "title" ( humanize "tags" ) ) }}
+                {{ partial "navigators/taxonomies.html" (dict "context" . "taxo" "star-tags" "title" ( humanize "tags" ) ) }}
             </div>
           </ul>
         </div>

--- a/layouts/stars/single.html
+++ b/layouts/stars/single.html
@@ -1,5 +1,5 @@
 {{ define "header" }}
-<meta name="description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Title }}{{ end }}" />
+{{ partial "single/header.html" . }}
 {{ end }}
 
 {{ define "navbar" }}
@@ -7,185 +7,13 @@
 {{ end }}
 
 {{ define "sidebar" }}
-<section class="sidebar-section" id="sidebar-section">
-    <div class="sidebar-holder">
-        <div class="sidebar" id="sidebar">
-            <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
-            <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
-            </form>
-            <div class="sidebar-tree">
-                <ul class="tree">
-                    <li style="padding-left: 0px !important;"><a href="{{ .Type | relLangURL }}" data-filter="all">{{ i18n .Type }}</a></li>
-                </ul>
-            </div>
-            <div class="sidebar-tree">
-                <ul class="tree" id="tree">
-                    <li id="list-heading">{{ i18n "star-tags" }}</li>
-                    <div class="subtree">
-                        {{ partial "navigators/star-taxonomies.html" (dict "context" . "taxo" "star-tags" "title" ( humanize "tags" ) ) }}
-                    </div>
-                </ul>
-            </div>
-        </div>
-    </div>
-</section>
+{{ partial "single/sidebar.html" (dict "context" . "taxo" "star-tags") }}
 {{ end }}
 
 {{ define "content" }}
-<section class="content-section" id="content-section">
-    <div class="content">
-        <div class="container p-0 read-area">
-            <!--Hero Area-->
-            <div class="hero-area col-sm-12" id="hero-area" style='background-image: url({{ .Params.heroUrl }});'>
-            </div>
-
-            <!--Content Start-->
-            <div class="page-content">
-                {{ if site.Params.features.blog.showAuthor | default true }}
-                <div class="author-profile ms-auto align-self-lg-center">
-                    <a href="{{ .Params.owner.html_url}}"><img class="rounded-circle" src='{{ .Params.owner.avatar_url }}' alt="Author Image"></a>
-                    <h5 class="author-name"><a href="{{ .Params.owner.html_url}}">{{ .Params.owner.login }}</a></h5>
-                    <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
-                </div>
-                {{ else }}
-                <div style="margin-bottom: 80px;"></div>
-                {{ end }}
-
-                <div class="title">
-                    <h1><a href="{{ .Params.html_url}}">{{ .Page.Title }}</a></h1>
-                </div>
-
-                {{ if not (site.Params.features.blog.showAuthor | default true) }}
-                <div class="author-profile ms-auto align-self-lg-center">
-                    <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
-                </div>
-                {{ end }}
-
-                {{ if site.Params.features.tags.enable }}
-                {{partial "misc/startags.html" (index .Params "star-tags" ) }}
-                {{ end }}
-                <div class="post-content" id="post-content">
-                    {{ .Page.Content }}
-                </div>
-
-                <!-- Share or Contribute -->
-                <div class="row ps-3 pe-3">
-                    <!--Social Media Share Buttons-->
-                    <div class="col-md-6 share-buttons">
-                        {{ if site.Params.features.blog.shareButtons }}
-                        <strong>{{ i18n "share_on" }}:</strong>
-                        {{ if site.Params.features.blog.shareButtons.facebook }}
-                        <a class="btn icon-button bg-facebook" href="https://www.facebook.com/sharer.php?u={{ .Permalink }}" target="_blank">
-                            <i class="fab fa-facebook"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.twitter }}
-                        <a class="btn icon-button bg-twitter" href="https://twitter.com/share?url={{ .Permalink }}&text={{ .Title }}&via={{- site.Title -}}" target="_blank">
-                            <i class="fab fa-twitter"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.reddit }}
-                        <a  class="btn icon-button bg-reddit" href="https://reddit.com/submit?url={{ .Permalink }}&title={{ .Title }}" target="_blank">
-                            <i class="fab fa-reddit"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.tumblr }}
-                        <a class="btn icon-button bg-tumblr" href="https://www.tumblr.com/share/link?url={{ .Permalink }}&name={{ .Title }}{{- with .Params.description -}}&description={{- . -}}{{- end -}}" target="_blank">
-                            <i class="fab fa-tumblr"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.pocket }}
-                        <a class="btn icon-button bg-pocket" href="https://getpocket.com/save?url={{ .Permalink }}&title={{ .Title }}" target="_blank">
-                            <i class="fab fa-get-pocket"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.linkedin }}
-                        <a class="btn icon-button bg-linkedin" href="https://www.linkedin.com/shareArticle?url={{ .Permalink }}&title={{ .Title }}" target="_blank">
-                            <i class="fab fa-linkedin"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.diaspora }}
-                        <a class="btn icon-button bg-diaspora" href="https://share.diasporafoundation.org/?title={{ .Title }}&url={{ .Permalink }}" rel="nofollow" target="_blank">
-                            <i class="fab fa-diaspora"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.mastodon }}
-                        <a class="btn icon-button bg-mastodon" href="https://mastodon.social/share?text={{ .Title }} - {{ .Permalink }}" target="_blank">
-                            <i class="fab fa-mastodon"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.whatsapp }}
-                        <a class="btn icon-button bg-whatsapp" href="https://api.whatsapp.com/send?text={{ .Title }} {{ .Permalink }}" target="_blank">
-                            <i class="fab fa-whatsapp"></i>
-                        </a>
-                        {{ end }}
-                        {{ if site.Params.features.blog.shareButtons.email }}
-                        <a class="btn icon-button" href="mailto:?subject={{ .Title }}&body={{ .Permalink }}" target="_blank">
-                            <i class="fas fa-envelope-open-text"></i>
-                        </a>
-                        {{ end }}
-                        {{ end }}
-                    </div>
-
-                    <!--- Improve this page button --->
-                    {{ if site.Params.GitRepo }}
-                    {{ if site.Params.GitBranch }}
-                    {{ .Scratch.Set "GitBranch" site.Params.GitBranch }}
-                    {{ else }}
-                    {{ .Scratch.Set "GitBranch" "main" }}
-                    {{ end }}
-                    <div class="col-md-6 btn-improve-page">
-                        {{ if ( eq site.Params.GitForge "gitlab" ) }}
-                        <a href="{{ site.Params.GitRepo }}/-/edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
-                        {{ else if ( eq site.Params.GitForge "gitea" ) }}
-                        <a href="{{ site.Params.GitRepo }}/_edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
-                        {{ else }} <!--- Make Github-style the default -->
-                        <a href="{{ site.Params.GitRepo }}/edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
-                        {{ end }}
-                        <i class="fas fa-code-branch"></i>
-                        {{ i18n "improve_this_page" }}
-                        </a>
-                    </div>
-                    {{ end }}
-                </div>
-
-
-
-                <!---Next and Previous Navigator -->
-                <hr />
-                {{ partial "navigators/next-prev-navigator.html" . }}
-                <hr />
-
-                <!----- Add comment support  ----->
-                {{ if site.Params.features.comment.enable }}
-                {{ partial "comments.html" site.Params.features.comment.services }}
-                {{ end }}
-
-                <!-- Keep backward compatibility with old config.yaml -->
-                {{ if .Site.Config.Services.Disqus.Shortname }}
-                {{ partial "comments/disqus.html" (dict (slice "disqus" "shortName")  .Site.Config.Services.Disqus.Shortname) }}
-                {{ end }}
-
-            </div>
-        </div>
-    </div>
-    <!--scroll back to top-->
-    <a id="scroll-to-top" class="btn" type="button" data-bs-toggle="tooltip" data-bs-placement="left" title="Scroll to top">
-        <i class="fas fa-chevron-circle-up"></i>
-    </a>
-</section>
+{{ partial "single/content.html" (dict "context" . "taxo" "star-tags") }}
 {{ end }}
 
 {{ define "toc" }}
-<section class="toc-section" id="toc-section">
-    {{ if and site.Params.features.toc.enable ( .Params.enableTOC | default true ) }}
-    <div class="toc-holder">
-        <h5 class="text-center ps-3">{{ i18n "toc_heading" }}</h5>
-        <hr>
-        <div class="toc">
-            {{ .TableOfContents }}
-        </div>
-    </div>
-    {{ end }}
-</section>
+{{ partial "single/toc.html" . }}
 {{ end }}


### PR DESCRIPTION
## Summary
- centralize taxonomies in a shared partial
- unify tag listing partial
- add shared partials for single page rendering
- simplify repo and star single layouts to use shared partials

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68457e243474832fb7735b93ff202934