### PR TITLE
Update Hugo version in workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.139.2'
+          hugo-version: '0.147.8'
           extended: true
 
       - name: Everything required


### PR DESCRIPTION
## Summary
- bump `actions/checkout` to v4
- use Hugo `0.147.8` in GitHub Pages workflow

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68477264e18c832f94ec75cbf8ca1502