### PR TITLE
Add Aurelies Dinners section with privacy policy

### DIFF
--- a/content/aurelies-dinners/_index.md
+++ b/content/aurelies-dinners/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Aurelies Dinners: Random Meals"
+date: 2024-10-24T00:00:00Z
+draft: false
+---
+
+Aurelies Dinners: Random Meals is an Android application (package name: `com.arran4.aurelies_dinners`).
+
+This page will be expanded with more details in the future.
+
+[Privacy Policy](privacy-policy/)

--- a/content/aurelies-dinners/privacy-policy.md
+++ b/content/aurelies-dinners/privacy-policy.md
@@ -1,0 +1,9 @@
+---
+title: "Privacy Policy"
+date: 2024-10-24T00:00:00Z
+draft: false
+---
+
+We do not collect any personal information in our application.
+
+Our application may link to external sites that are not operated by us. Please note that we have no control over the content and practices of these sites, and cannot accept responsibility or liability for their respective privacy policies.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -55,6 +55,8 @@ params:
       url: /stars/
     - name: Repos
       url: /repos/
+    - name: Aurelies Dinners
+      url: /aurelies-dinners/
 
   features:
     toc:


### PR DESCRIPTION
## Summary
- add Aurelies Dinners app section
- include minimal privacy policy for the app
- expose section in navigation menu

## Testing
- `hugo --minify` *(fails: command hangs and produces no completion output)*

------
https://chatgpt.com/codex/tasks/task_e_689d4c7b09b0832fb3407bf5bdb21b69