### PR TITLE
Add privacy policy for Cook Times app

### DIFF
--- a/content/privacy/cook-times.md
+++ b/content/privacy/cook-times.md
@@ -1,0 +1,39 @@
+---
+title: "Cook Times App Privacy Policy"
+date: 2024-12-18
+draft: false
+---
+
+## Privacy Policy for Cook Times App
+
+**Package Name:** `com.arran4.cooking_times.cook_times`
+
+**Effective Date:** 2024-12-18
+
+### Introduction
+Thank you for using the **Cook Times App**. Your privacy is important to us, and we are committed to maintaining transparency about how your data is handled. This privacy policy explains that our app does not collect or share any personal information.
+
+### Data Collection
+The Cook Times App does **not collect, store, or share any personal data**. All calculations performed within the app are executed locally on your device.
+
+### Internet and Network Usage
+The app does not require an internet connection to function and does not access any network resources. This ensures that your information stays private and secure.
+
+### Third-Party Services
+The Cook Times App does not integrate with any third-party services, analytics tools, or advertising platforms. As a result, no external entities receive any information about you or your usage of the app.
+
+### Permissions
+The app does not request any permissions to access sensitive data or device features.
+
+### Changes to This Privacy Policy
+While we do not anticipate changes to this privacy policy, we reserve the right to update it in the future. Any changes will be reflected on this page.
+
+### Contact Us
+If you have any questions about this privacy policy or the app, please contact us at:
+
+**Email:** cooktime@arran4.com
+
+---
+
+This privacy policy applies solely to the **Cook Times App** and its users.
+


### PR DESCRIPTION
## Summary
- add privacy policy page for the Cook Times Android app, including package name and contact details

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./...`
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d4ceff98c832fa7b2898b6c9b0000