### PR TITLE
Add Protein Calculator app privacy policy

### DIFF
--- a/content/privacy/protein-calculator.md
+++ b/content/privacy/protein-calculator.md
@@ -1,0 +1,38 @@
+---
+title: "Protein Calculator App Privacy Policy"
+date: 2024-12-17
+draft: false
+---
+
+## Privacy Policy for Protein Calculator App
+
+**Package Name:** `com.arran4.protiencalculator.protein_calc`
+
+**Effective Date:** 2024-12-17
+
+### Introduction
+Thank you for using the **Protein Calculator App**. Your privacy is important to us, and we are committed to maintaining transparency about how your data is handled. This privacy policy explains that our app does not collect or share any personal information.
+
+### Data Collection
+The Protein Calculator App does **not collect, store, or share any personal data**. All calculations performed within the app are executed locally on your device.
+
+### Internet and Network Usage
+The app does not require an internet connection to function and does not access any network resources. This ensures that your information stays private and secure.
+
+### Third-Party Services
+The Protein Calculator App does not integrate with any third-party services, analytics tools, or advertising platforms. As a result, no external entities receive any information about you or your usage of the app.
+
+### Permissions
+The app does not request any permissions to access sensitive data or device features.
+
+### Changes to This Privacy Policy
+While we do not anticipate changes to this privacy policy, we reserve the right to update it in the future. Any changes will be reflected on this page.
+
+### Contact Us
+If you have any questions about this privacy policy or the app, please contact us at:
+
+**Email:** proteincalc@arran4.com
+
+---
+
+This privacy policy applies solely to the **Protein Calculator App** and its users.


### PR DESCRIPTION
## Summary
- add privacy policy page for Protein Calculator Android app

## Testing
- `hugo --minify` *(fails: template partial error: can't evaluate field Sass; theme requires newer Hugo)*

------
https://chatgpt.com/codex/tasks/task_e_689d526d8c04832faa004050582bc810