### PR TITLE
Remove Aurelies Dinners menu entry and add app layout

### DIFF
--- a/content/arrans-movie-night-scheduler/_index.md
+++ b/content/arrans-movie-night-scheduler/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Arran's Movie Night Scheduler"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/arrans-movie-night-scheduler/privacy/_index.md
+++ b/content/arrans-movie-night-scheduler/privacy/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Arran's Movie Night Scheduler Privacy Policy"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/aurelies-dinners/_index.md
+++ b/content/aurelies-dinners/_index.md
@@ -2,6 +2,7 @@
 title: "Aurelies Dinners: Random Meals"
 date: 2024-10-24T00:00:00Z
 draft: false
+layout: app
 ---
 
 Aurelies Dinners: Random Meals is an Android application (package name: `com.arran4.aurelies_dinners`).

--- a/content/aurelies-dinners/privacy-policy.md
+++ b/content/aurelies-dinners/privacy-policy.md
@@ -2,6 +2,7 @@
 title: "Privacy Policy"
 date: 2024-10-24T00:00:00Z
 draft: false
+layout: app
 ---
 
 We do not collect any personal information in our application.

--- a/content/cbz-viewer/_index.md
+++ b/content/cbz-viewer/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "CBZ Viewer"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/cbz-viewer/privacy/_index.md
+++ b/content/cbz-viewer/privacy/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "CBZ Viewer Privacy Policy"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/cook-times/_index.md
+++ b/content/cook-times/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Cook Times"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/cook-times/privacy/_index.md
+++ b/content/cook-times/privacy/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Cook Times Privacy Policy"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/gizmo-card-creator/_index.md
+++ b/content/gizmo-card-creator/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Gizmo Card Creator"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/gizmo-card-creator/privacy/_index.md
+++ b/content/gizmo-card-creator/privacy/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Gizmo Card Creator Privacy Policy"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/protein-calculator/_index.md
+++ b/content/protein-calculator/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Protein Calculator"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/protein-calculator/privacy/_index.md
+++ b/content/protein-calculator/privacy/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Protein Calculator Privacy Policy"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/rpg-gym-stats/_index.md
+++ b/content/rpg-gym-stats/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "RPG Gym Stats"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/content/rpg-gym-stats/privacy/_index.md
+++ b/content/rpg-gym-stats/privacy/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "RPG Gym Stats Privacy Policy"
 draft: false
+layout: app
 sitemap_exclude: true
 _build:
   list: never

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -55,8 +55,6 @@ params:
       url: /stars/
     - name: Repos
       url: /repos/
-    - name: Aurelies Dinners
-      url: /aurelies-dinners/
 
   features:
     toc:

--- a/layouts/app/list.html
+++ b/layouts/app/list.html
@@ -1,0 +1,23 @@
+{{ define "header" }}
+{{ partial "single/header.html" . }}
+{{ end }}
+
+{{ define "navbar" }}
+{{ partial "navigators/navbar.html" . }}
+{{ end }}
+
+{{ define "sidebar" }}{{ end }}
+
+{{ define "content" }}
+<section class="content-section" id="content-section">
+  <div class="content">
+    <div class="container p-0 read-area">
+      <div class="page-content">
+        <div class="post-content" id="post-content">
+          {{ .Content }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}

--- a/layouts/app/single.html
+++ b/layouts/app/single.html
@@ -1,0 +1,27 @@
+{{ define "header" }}
+{{ partial "single/header.html" . }}
+{{ end }}
+
+{{ define "navbar" }}
+{{ partial "navigators/navbar.html" . }}
+{{ end }}
+
+{{ define "sidebar" }}{{ end }}
+
+{{ define "content" }}
+<section class="content-section" id="content-section">
+  <div class="content">
+    <div class="container p-0 read-area">
+      <div class="page-content">
+        <div class="post-content" id="post-content">
+          {{ .Content }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+
+{{ define "toc" }}
+{{ partial "single/toc.html" . }}
+{{ end }}


### PR DESCRIPTION
## Summary
- remove Aurelies Dinners from site menu
- add dedicated `app` layout template and apply to all app and privacy pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `hugo` *(fails: command not found: hugo)*

------
https://chatgpt.com/codex/tasks/task_e_689da8531fa0832fab50cefcd1a8b912