### PR TITLE
Fix privacy policy page paths

### DIFF
--- a/content/privacy/arrans-movie-night-scheduler/index.md
+++ b/content/privacy/arrans-movie-night-scheduler/index.md
@@ -2,7 +2,9 @@
 title: "Arran's Movie Night Scheduler Privacy Policy"
 draft: false
 layout: app
+slug: privacy
 sitemap_exclude: true
+url: /arrans-movie-night-scheduler/privacy/
 ---
 
 This app uses your Google account to log in. Aside from the credentials required for authentication, no personal data is collected, stored, or shared. The app currently does not integrate any third-party services. If this changes, this policy will be updated.

--- a/content/privacy/aurelies-dinners/index.md
+++ b/content/privacy/aurelies-dinners/index.md
@@ -1,8 +1,11 @@
 ---
-title: "Privacy Policy"
+title: "Aurelie's Dinners Privacy Policy"
 date: 2024-10-24T00:00:00Z
 draft: false
 layout: app
+slug: privacy
+sitemap_exclude: true
+url: /aurelies-dinners/privacy/
 ---
 
 We do not collect, store, or share any personal information in our application. All meal data you enter stays on your device and is removed when the app is uninstalled.

--- a/content/privacy/cbz-viewer/index.md
+++ b/content/privacy/cbz-viewer/index.md
@@ -2,7 +2,9 @@
 title: "CBZ Viewer Privacy Policy"
 draft: false
 layout: app
+slug: privacy
 sitemap_exclude: true
+url: /cbz-viewer/privacy/
 ---
 
 CBZ Viewer does not collect, store, or share any personal data. All activity occurs locally on your device and no third-party services are used. If this changes in the future, this policy will be updated.

--- a/content/privacy/cook-times/index.md
+++ b/content/privacy/cook-times/index.md
@@ -2,7 +2,9 @@
 title: "Cook Times Privacy Policy"
 draft: false
 layout: app
+slug: privacy
 sitemap_exclude: true
+url: /cook-times/privacy/
 ---
 
 Cook Times does not collect, store, or share personal data. The app works entirely offline on your device and uses no third-party services. Should this change, the policy will be updated.

--- a/content/privacy/gizmo-card-creator/index.md
+++ b/content/privacy/gizmo-card-creator/index.md
@@ -2,7 +2,9 @@
 title: "Gizmo Card Creator Privacy Policy"
 draft: false
 layout: app
+slug: privacy
 sitemap_exclude: true
+url: /gizmo-card-creator/privacy/
 ---
 
 Gizmo Card Creator does not collect, store, or share personal data. It runs locally on your device and uses no third-party services. If this ever changes, this policy will be updated accordingly.

--- a/content/privacy/protein-calculator/index.md
+++ b/content/privacy/protein-calculator/index.md
@@ -2,7 +2,9 @@
 title: "Protein Calculator Privacy Policy"
 draft: false
 layout: app
+slug: privacy
 sitemap_exclude: true
+url: /protein-calculator/privacy/
 ---
 
 Protein Calculator does not collect, store, or share personal data. All calculations happen on your device and the app uses no third-party services. Any future changes will be reflected in this policy.

--- a/content/privacy/rpg-gym-stats/index.md
+++ b/content/privacy/rpg-gym-stats/index.md
@@ -2,7 +2,9 @@
 title: "RPG Gym Stats Privacy Policy"
 draft: false
 layout: app
+slug: privacy
 sitemap_exclude: true
+url: /rpg-gym-stats/privacy/
 ---
 
 RPG Gym Stats does not collect, store, or share personal data. The app runs entirely on your device without third-party integrations. If our practices change, we will update this policy.


### PR DESCRIPTION
## Summary
- Move app privacy policies into a dedicated `content/privacy` directory
- Configure URLs so each policy lives under `<app>/privacy/`

## Testing
- `npm test` *(fails: Missing script "test")*
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_689dc0203224832faf261077f50b8b75