### PR TITLE
docs: add CBZ Viewer privacy layout and publish date

### DIFF
--- a/content/privacy/cbz-viewer/index.md
+++ b/content/privacy/cbz-viewer/index.md
@@ -1,12 +1,33 @@
 ---
 title: "CBZ Viewer Privacy Policy"
+date: 2024-12-30T00:00:00Z
+publishDate: 2024-12-30T00:00:00Z
 draft: false
-layout: app
+layout: privacy
 slug: privacy
 sitemap_exclude: true
 url: /cbz-viewer/privacy/
 ---
 
-CBZ Viewer does not collect, store, or share any personal data. All activity occurs locally on your device and no third-party services are used. If this changes in the future, this policy will be updated.
+**Effective Date:** December 30, 2024
 
-Contact: cbzviewer@arran4.com
+## Overview
+CBZ Viewer respects your privacy and is committed to protecting it. This privacy policy outlines how CBZ Viewer handles your data.
+
+## Data Collection
+CBZ Viewer does not collect, store, or transmit any personal data or usage information.
+
+## Permissions
+The app may request permissions necessary to access your local storage for the purpose of reading and displaying CBZ files. These permissions are solely used for the app's functionality and do not involve data collection or sharing.
+
+## Third-Party Services
+CBZ Viewer does not integrate with any third-party services or analytics tools.
+
+## Changes to This Privacy Policy
+As CBZ Viewer does not collect or use your data, this privacy policy is unlikely to change. However, if changes are made, they will be reflected in an updated version of this document with a new effective date.
+
+## Contact
+If you have any questions about this privacy policy, please contact us:
+**Email:** [cbzviewer@arran4.com](mailto:cbzviewer@arran4.com)
+
+Thank you for using CBZ Viewer.

--- a/layouts/privacy/single.html
+++ b/layouts/privacy/single.html
@@ -1,0 +1,28 @@
+{{ define "header" }}
+{{ partial "single/header.html" . }}
+{{ end }}
+
+{{ define "navbar" }}
+{{ partial "navigators/navbar.html" . }}
+{{ end }}
+
+{{ define "sidebar" }}{{ end }}
+
+{{ define "content" }}
+<section class="content-section" id="content-section">
+  <div class="content">
+    <div class="container p-0 read-area">
+      <div class="page-content">
+        <div class="post-content" id="post-content">
+          {{ .Content }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+
+{{ define "toc" }}
+{{ partial "single/toc.html" . }}
+{{ end }}
+


### PR DESCRIPTION
## Summary
- add publish date to CBZ Viewer privacy policy
- introduce dedicated layout for privacy policies

## Testing
- `npm test` *(fails: Missing script "test")*
- `hugo` *(fails: can't evaluate field Sass in type interface {})*

------
https://chatgpt.com/codex/tasks/task_e_689dcdb5fc58832f9c4f4d3c6ef5a97e