### PR TITLE
feat: add detailed cook times privacy policy

### DIFF
--- a/content/privacy/cook-times/index.md
+++ b/content/privacy/cook-times/index.md
@@ -1,12 +1,36 @@
 ---
 title: "Cook Times Privacy Policy"
+date: 2024-12-18T00:00:00Z
 draft: false
-layout: app
+layout: privacy
 slug: privacy
 sitemap_exclude: true
 url: /cook-times/privacy/
 ---
 
-Cook Times does not collect, store, or share personal data. The app works entirely offline on your device and uses no third-party services. Should this change, the policy will be updated.
+**Effective Date:** 2024-12-18
 
-Contact: cooktime@arran4.com
+## Introduction
+Thank you for using the **Cook Times App**. Your privacy is important to us, and we are committed to maintaining transparency about how your data is handled. This privacy policy explains that our app does not collect or share any personal information.
+
+## Data Collection
+The Cook Times App does **not collect, store, or share any personal data**. All calculations performed within the app are executed locally on your device.
+
+## Internet and Network Usage
+The app does not require an internet connection to function and does not access any network resources. This ensures that your information stays private and secure.
+
+## Third-Party Services
+The Cook Times App does not integrate with any third-party services, analytics tools, or advertising platforms. As a result, no external entities receive any information about you or your usage of the app.
+
+## Permissions
+The app does not request any permissions to access sensitive data or device features.
+
+## Changes to This Privacy Policy
+While we do not anticipate changes to this privacy policy, we reserve the right to update it in the future. Any changes will be reflected on this page.
+
+## Contact Us
+If you have any questions about this privacy policy or the app, please contact us at:
+
+**Email:** cooktime@arran4.com
+
+This privacy policy applies solely to the **Cook Times App** and its users.

--- a/layouts/privacy/single.html
+++ b/layouts/privacy/single.html
@@ -1,0 +1,23 @@
+{{ define "header" }}
+{{ partial "single/header.html" . }}
+{{ end }}
+
+{{ define "navbar" }}
+{{ partial "navigators/navbar.html" . }}
+{{ end }}
+
+{{ define "sidebar" }}{{ end }}
+
+{{ define "content" }}
+<section class="content-section" id="content-section">
+  <div class="content">
+    <div class="container p-0 read-area">
+      <div class="page-content">
+        <div class="post-content" id="post-content">
+          {{ .Content }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}


### PR DESCRIPTION
## Summary
- add dedicated privacy layout for Cook Times app
- set Cook Times privacy policy to use the new layout with structured sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./...`
- `hugo --minify` *(fails: module min version and Sass field errors)*

------
https://chatgpt.com/codex/tasks/task_e_689dcdbbc484832f97d66eb126d8e4bf