### PR TITLE
Standardize app layouts and privacy pages

### DIFF
--- a/content/arrans-movie-night-scheduler/index.md
+++ b/content/arrans-movie-night-scheduler/index.md
@@ -1,8 +1,9 @@
 ---
 title: "Arran's Movie Night Scheduler"
 draft: false
-layout: app
+layout: arrans-movie-night-scheduler
 sitemap_exclude: true
+description: "Plan movie nights with friends using suggestions and votes."
 ---
 
 Arran's Movie Night Scheduler helps you plan movie nights with friends by keeping track of suggestions and votes.

--- a/content/aurelies-dinners/index.md
+++ b/content/aurelies-dinners/index.md
@@ -2,6 +2,8 @@
 title: "Aurelies Dinners: Random Meals"
 date: 2024-10-24T00:00:00Z
 draft: false
+layout: aurelies-dinners
+description: "Pick a random meal from your saved recipes."
 ---
 
 Aurelies Dinners: Random Meals is an Android application (package name: `com.arran4.aurelies_dinners`). It helps you decide what to cook by suggesting a random meal from your saved recipes.
@@ -15,4 +17,4 @@ Aurelies Dinners: Random Meals is an Android application (package name: `com.arr
 
 [Get it on Google Play](https://play.google.com/store/apps/details?id=com.arran4.aurelies_dinners)
 
-[Privacy Policy](privacy-policy/)
+[Privacy Policy](privacy/)

--- a/content/cbz-viewer/index.md
+++ b/content/cbz-viewer/index.md
@@ -1,7 +1,9 @@
 ---
 title: "CBZ Viewer"
 draft: false
+layout: cbz-viewer
 sitemap_exclude: true
+description: "Lightweight comic book reader for CBZ archives."
 ---
 
 CBZ Viewer is a lightweight comic book reader that opens your CBZ archives with ease.

--- a/content/cook-times/index.md
+++ b/content/cook-times/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Cook Times"
 draft: false
+layout: cook-times
 sitemap_exclude: true
+description: "Track parallel kitchen timers for multiple dishes."
 ---
 
 Cook Times keeps your kitchen organized by tracking multiple dishes at once.

--- a/content/gizmo-card-creator/index.md
+++ b/content/gizmo-card-creator/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Gizmo Card Creator"
 draft: false
+layout: gizmo-card-creator
 sitemap_exclude: true
+description: "Design and print custom cards for the Gizmo board game."
 ---
 
 Gizmo Card Creator lets you design and print custom cards for the Gizmo board game.

--- a/content/lojban-messenger-dictionary/index.md
+++ b/content/lojban-messenger-dictionary/index.md
@@ -2,7 +2,9 @@
 title: "Lojban Dictionary for Facebook Messenger"
 date: 2024-02-22T00:00:00Z
 draft: false
+layout: lojban-messenger-dictionary
 sitemap_exclude: true
+description: "Lookup Lojban words directly in Messenger." 
 ---
 
 Lojban Dictionary for Facebook Messenger is a chatbot that lets you look up Lojban words directly within Facebook Messenger conversations.

--- a/content/privacy/arrans-movie-night-scheduler/index.md
+++ b/content/privacy/arrans-movie-night-scheduler/index.md
@@ -6,6 +6,7 @@ layout: arrans-movie-night-scheduler
 slug: privacy
 sitemap_exclude: true
 url: /arrans-movie-night-scheduler/privacy/
+description: "Privacy policy for Arran's Movie Night Scheduler app."
 ---
 
 Privacy Policy

--- a/content/privacy/aurelies-dinners/index.md
+++ b/content/privacy/aurelies-dinners/index.md
@@ -2,18 +2,25 @@
 title: "Aurelie's Dinners Privacy Policy"
 date: 2024-10-24T00:00:00Z
 draft: false
-layout: app
+layout: aurelies-dinners
 slug: privacy
 sitemap_exclude: true
 url: /aurelies-dinners/privacy/
+description: "Privacy policy for Aurelie's Dinners: Random Meals."
 ---
 
-We do not collect, store, or share any personal information in our application. All meal data you enter stays on your device and is removed when the app is uninstalled.
+## Introduction
+Aurelie's Dinners: Random Meals does not collect, store, or share any personal information. All meal data you enter stays on your device and is removed when the app is uninstalled.
 
+## Data Collection
 The app does not use analytics, cookies, or third-party SDKs. Network access is only used when you choose to follow external links, such as the Google Play listing or recipe sites you add yourself.
 
-Our application may link to external sites that are not operated by us. Please note that we have no control over the content and practices of these sites, and cannot accept responsibility or liability for their respective privacy policies.
+## Third-Party Links
+Our application may link to external sites that are not operated by us. We have no control over the content and practices of these sites and cannot accept responsibility for their privacy policies.
 
-If you have any questions or concerns about this policy, please contact `aureliesdinners@arran4.com`.
-
+## Changes to This Privacy Policy
 This policy may be updated from time to time. Any changes will be posted on this page.
+
+## Contact Us
+If you have any questions or concerns about this policy, please contact us at:
+**Email:** [aureliesdinners@arran4.com](mailto:aureliesdinners@arran4.com)

--- a/content/privacy/cbz-viewer/index.md
+++ b/content/privacy/cbz-viewer/index.md
@@ -3,10 +3,11 @@ title: "CBZ Viewer Privacy Policy"
 date: 2024-12-30T00:00:00Z
 publishDate: 2024-12-30T00:00:00Z
 draft: false
-layout: privacy
+layout: cbz-viewer
 slug: privacy
 sitemap_exclude: true
 url: /cbz-viewer/privacy/
+description: "Privacy policy for the CBZ Viewer app."
 ---
 
 **Effective Date:** December 30, 2024
@@ -22,6 +23,12 @@ The app may request permissions necessary to access your local storage for the p
 
 ## Third-Party Services
 CBZ Viewer does not integrate with any third-party services or analytics tools.
+
+## Data Security
+All files you open remain on your device. No information is transmitted or stored externally.
+
+## Children's Privacy
+CBZ Viewer does not target children and does not knowingly collect data from children under 13.
 
 ## Changes to This Privacy Policy
 As CBZ Viewer does not collect or use your data, this privacy policy is unlikely to change. However, if changes are made, they will be reflected in an updated version of this document with a new effective date.

--- a/content/privacy/cook-times/index.md
+++ b/content/privacy/cook-times/index.md
@@ -2,10 +2,11 @@
 title: "Cook Times Privacy Policy"
 date: 2024-12-18T00:00:00Z
 draft: false
-layout: privacy
+layout: cook-times
 slug: privacy
 sitemap_exclude: true
 url: /cook-times/privacy/
+description: "Privacy policy for the Cook Times app."
 ---
 
 **Effective Date:** 2024-12-18

--- a/content/privacy/gizmo-card-creator/index.md
+++ b/content/privacy/gizmo-card-creator/index.md
@@ -6,6 +6,7 @@ layout: gizmo-card-creator
 slug: privacy
 sitemap_exclude: true
 url: /gizmo-card-creator/privacy/
+description: "Privacy policy for the Gizmo Card Creator app."
 ---
 
 Ubels Software Development built the Gizmo Card Creator app as a Free app. This SERVICE is provided by Ubels Software Development at no cost and is intended for use as is.

--- a/content/privacy/lojban-messenger-dictionary/index.md
+++ b/content/privacy/lojban-messenger-dictionary/index.md
@@ -2,10 +2,11 @@
 title: "Lojban Dictionary for Facebook Messenger Privacy Policy"
 date: 2024-02-22T00:00:00Z
 draft: false
-layout: privacy
+layout: lojban-messenger-dictionary
 slug: privacy
 sitemap_exclude: true
 url: /lojban-messenger-dictionary/privacy/
+description: "Privacy policy for the Lojban Dictionary for Facebook Messenger."
 ---
 Last updated: February 22, 2024
 

--- a/content/privacy/protein-calculator/index.md
+++ b/content/privacy/protein-calculator/index.md
@@ -2,9 +2,11 @@
 title: "Privacy Policy for Protein Calculator App"
 date: 2024-12-17T00:00:00Z
 draft: false
+layout: protein-calculator
 slug: privacy
 sitemap_exclude: true
 url: /protein-calculator/privacy/
+description: "Privacy policy for the Protein Calculator app."
 ---
 
 **Effective Date:** 2024-12-17

--- a/content/privacy/rpg-gym-stats/index.md
+++ b/content/privacy/rpg-gym-stats/index.md
@@ -6,6 +6,7 @@ layout: rpg-gym-stats
 slug: privacy
 sitemap_exclude: true
 url: /rpg-gym-stats/privacy/
+description: "Privacy policy for the RPG Gym Stats app."
 ---
 
 Ubels Software Development built the RPG Gym Stats app as a Free app. This SERVICE is provided by Ubels Software Development at no cost and is intended for use as is.

--- a/content/protein-calculator/index.md
+++ b/content/protein-calculator/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Protein Calculator"
 draft: false
+layout: protein-calculator
 sitemap_exclude: true
+description: "Estimate daily protein needs based on weight and goals."
 ---
 
 Protein Calculator estimates how much protein you need each day based on your weight and goals.

--- a/content/rpg-gym-stats/index.md
+++ b/content/rpg-gym-stats/index.md
@@ -1,7 +1,9 @@
 ---
 title: "RPG Gym Stats"
 draft: false
+layout: rpg-gym-stats
 sitemap_exclude: true
+description: "Turn workouts into an adventure with XP and achievements."
 ---
 
 RPG Gym Stats turns your workouts into an adventure where every rep earns experience.

--- a/layouts/aurelies-dinners/single.html
+++ b/layouts/aurelies-dinners/single.html
@@ -2,11 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ .Title }}</title>
+  {{ with .Params.description }}
+  <meta name="description" content="{{ . }}" />
+  {{ end }}
   <link rel="stylesheet" href="{{ "aurelies-dinners/style.css" | relURL }}">
 </head>
 <body>
   <main class="content">
+    <h1>{{ .Title }}</h1>
+    {{ with .PublishDate }}
+    <p><time datetime="{{ . }}">{{ .Format "2006-01-02" }}</time></p>
+    {{ end }}
     {{ .Content }}
   </main>
 </body>

--- a/layouts/cbz-viewer/single.html
+++ b/layouts/cbz-viewer/single.html
@@ -2,11 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ .Title }}</title>
+  {{ with .Params.description }}
+  <meta name="description" content="{{ . }}" />
+  {{ end }}
   <link rel="stylesheet" href="{{ "cbz-viewer/style.css" | relURL }}">
 </head>
 <body>
   <main class="content">
+    <h1>{{ .Title }}</h1>
+    {{ with .PublishDate }}
+    <p><time datetime="{{ . }}">{{ .Format "2006-01-02" }}</time></p>
+    {{ end }}
     {{ .Content }}
   </main>
 </body>

--- a/layouts/cook-times/single.html
+++ b/layouts/cook-times/single.html
@@ -2,11 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ .Title }}</title>
+  {{ with .Params.description }}
+  <meta name="description" content="{{ . }}" />
+  {{ end }}
   <link rel="stylesheet" href="{{ "cook-times/style.css" | relURL }}">
 </head>
 <body>
   <main class="content">
+    <h1>{{ .Title }}</h1>
+    {{ with .PublishDate }}
+    <p><time datetime="{{ . }}">{{ .Format "2006-01-02" }}</time></p>
+    {{ end }}
     {{ .Content }}
   </main>
 </body>

--- a/layouts/gizmo-card-creator/single.html
+++ b/layouts/gizmo-card-creator/single.html
@@ -2,12 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ .Title }}</title>
+  {{ with .Params.description }}
+  <meta name="description" content="{{ . }}" />
+  {{ end }}
   <link rel="stylesheet" href="{{ "gizmo-card-creator/style.css" | relURL }}">
 </head>
 <body>
   <main class="content">
     <h1>{{ .Title }}</h1>
+    {{ with .PublishDate }}
+    <p><time datetime="{{ . }}">{{ .Format "2006-01-02" }}</time></p>
+    {{ end }}
     {{ .Content }}
   </main>
 </body>

--- a/layouts/lojban-messenger-dictionary/single.html
+++ b/layouts/lojban-messenger-dictionary/single.html
@@ -7,7 +7,7 @@
   {{ with .Params.description }}
   <meta name="description" content="{{ . }}" />
   {{ end }}
-  <link rel="stylesheet" href="{{ "arrans-movie-night-scheduler/style.css" | relURL }}">
+  <link rel="stylesheet" href="{{ "lojban-messenger-dictionary/style.css" | relURL }}">
 </head>
 <body>
   <main class="content">

--- a/layouts/protein-calculator/single.html
+++ b/layouts/protein-calculator/single.html
@@ -2,11 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ .Title }}</title>
+  {{ with .Params.description }}
+  <meta name="description" content="{{ . }}" />
+  {{ end }}
   <link rel="stylesheet" href="{{ "protein-calculator/style.css" | relURL }}">
 </head>
 <body>
   <main class="content">
+    <h1>{{ .Title }}</h1>
+    {{ with .PublishDate }}
+    <p><time datetime="{{ . }}">{{ .Format "2006-01-02" }}</time></p>
+    {{ end }}
     {{ .Content }}
   </main>
 </body>

--- a/layouts/rpg-gym-stats/single.html
+++ b/layouts/rpg-gym-stats/single.html
@@ -2,7 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ .Title }}</title>
+  {{ with .Params.description }}
+  <meta name="description" content="{{ . }}" />
+  {{ end }}
   <link rel="stylesheet" href="{{ "rpg-gym-stats/style.css" | relURL }}">
 </head>
 <body>

--- a/static/lojban-messenger-dictionary/style.css
+++ b/static/lojban-messenger-dictionary/style.css
@@ -1,0 +1,16 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #fafafa;
+  color: #333;
+}
+main.content {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+h1 {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}


### PR DESCRIPTION
## Summary
- add consistent meta tags and optional publish dates to app-specific layouts
- align privacy policies with matching layouts and descriptions
- expand privacy content for CBZ Viewer and Aurelie's Dinners

## Testing
- `hugo` *(fails: Module "github.com/hugo-toha/toha/v4" is not compatible with this Hugo version)*

------
https://chatgpt.com/codex/tasks/task_e_689dd6659db0832f8a79abc4807863b1