### PR TITLE
Fix app and developer identification in Protein to Weight Calculator privacy policy

### DIFF
--- a/content/privacy/protein-calculator/index.md
+++ b/content/privacy/protein-calculator/index.md
@@ -1,27 +1,27 @@
 ---
-title: "Privacy Policy for Protein Calculator App"
+title: "Privacy Policy for Protein to Weight Calculator"
 date: 2024-12-17T00:00:00Z
 draft: false
 layout: protein-calculator
 slug: privacy
 sitemap_exclude: true
 url: /protein-calculator/privacy/
-description: "Privacy policy for the Protein Calculator app."
+description: "Privacy policy for the Protein to Weight Calculator app."
 ---
 
 **Effective Date:** 2024-12-17
 
 ### Introduction
-Thank you for using the **Protein Calculator App**. Your privacy is important to us, and we are committed to maintaining transparency about how your data is handled. This privacy policy explains that our app does not collect or share any personal information.
+Thank you for using the **Protein to Weight Calculator**. Arran4 ("we", "us", or "our") is the developer of this app. Your privacy is important to us, and we are committed to maintaining transparency about how your data is handled. This privacy policy explains that our app does not collect or share any personal information.
 
 ### Data Collection
-The Protein Calculator App does **not collect, store, or share any personal data**. All calculations performed within the app are executed locally on your device.
+The Protein to Weight Calculator does **not collect, store, or share any personal data**. All calculations performed within the app are executed locally on your device.
 
 ### Internet and Network Usage
 The app does not require an internet connection to function and does not access any network resources. This ensures that your information stays private and secure.
 
 ### Third-Party Services
-The Protein Calculator App does not integrate with any third-party services, analytics tools, or advertising platforms. As a result, no external entities receive any information about you or your usage of the app.
+The Protein to Weight Calculator does not integrate with any third-party services, analytics tools, or advertising platforms. As a result, no external entities receive any information about you or your usage of the app.
 
 ### Permissions
 The app does not request any permissions to access sensitive data or device features.
@@ -30,10 +30,10 @@ The app does not request any permissions to access sensitive data or device feat
 While we do not anticipate changes to this privacy policy, we reserve the right to update it in the future. Any changes will be reflected on this page.
 
 ### Contact Us
-If you have any questions about this privacy policy or the app, please contact us at:
+If you have any questions about this privacy policy or the app, please contact Arran4 at:
 
 **Email:** proteincalc@arran4.com
 
 ---
 
-This privacy policy applies solely to the **Protein Calculator App** and its users.
+This privacy policy applies solely to the **Protein to Weight Calculator** app, developed by Arran4, and its users.


### PR DESCRIPTION
## Summary
- Clarify that the privacy policy applies to the Protein to Weight Calculator app and explicitly identify Arran4 as the developer.

## Testing
- `npm test` *(fails: Missing script "test")*
- `hugo` *(fails: module toha/v4 is not compatible; can't evaluate field Sass)*

------
https://chatgpt.com/codex/tasks/task_e_689ddcd6b5bc832f984dfeb2df8f262f