### PR TITLE
fix: correct Aurelies Dinners privacy link

### DIFF
--- a/content/aurelies-dinners/index.md
+++ b/content/aurelies-dinners/index.md
@@ -17,4 +17,4 @@ Aurelies Dinners: Random Meals is an Android application (package name: `com.arr
 
 [Get it on Google Play](https://play.google.com/store/apps/details?id=com.arran4.aurelies_dinners)
 
-[Privacy Policy](privacy/)
+[Privacy Policy](/aurelies-dinners/privacy/)


### PR DESCRIPTION
## Summary
- fix privacy policy link for Aurelie's Dinners page to point to the correct URL

## Testing
- `hugo -D` *(fails: Module "github.com/hugo-toha/toha/v4" is not compatible with this Hugo version)*

------
https://chatgpt.com/codex/tasks/task_e_689ddd8a8f30832f997605e7bd998ec0