### PR TITLE
clarify personal data policy in app privacy pages

### DIFF
--- a/content/privacy/gizmo-card-creator/index.md
+++ b/content/privacy/gizmo-card-creator/index.md
@@ -19,7 +19,7 @@ The terms used in this Privacy Policy have the same meanings as in our Terms and
 
 ## Information Collection and Use
 
-For a better experience, while using our Service, I may require you to provide us with certain personally identifiable information, including but not limited to None. The information that I request will be retained on your device and is not collected by me in any way.
+For a better experience, while using our Service, I may require you to provide us with certain personally identifiable information. The app does not collect personal data. The information that I request will be retained on your device and is not collected by me in any way.
 
 The app does use third-party services that may collect information used to identify you.
 

--- a/content/privacy/rpg-gym-stats/index.md
+++ b/content/privacy/rpg-gym-stats/index.md
@@ -19,7 +19,7 @@ The terms used in this Privacy Policy have the same meanings as in our Terms and
 
 **Information Collection and Use**
 
-For a better experience, while using our Service, I may require you to provide us with certain personally identifiable information, including but not limited to None. The information that I request will be retained on your device and is not collected by me in any way.
+For a better experience, while using our Service, I may require you to provide us with certain personally identifiable information. The app does not collect personal data. The information that I request will be retained on your device and is not collected by me in any way.
 
 The app does use third-party services that may collect information used to identify you.
 


### PR DESCRIPTION
## Summary
- Clarify that the Gizmo Card Creator and RPG Gym Stats apps do not collect personal data

## Testing
- `npm test` *(fails: Missing script "test")*
- `hugo` *(fails: error calling partial helpers/style-bundle.html)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf3fb9a0832fbfa25d19b964cfaf