### PR TITLE
docs: link protein calculator email

### DIFF
--- a/content/privacy/protein-calculator/index.md
+++ b/content/privacy/protein-calculator/index.md
@@ -32,7 +32,7 @@ While we do not anticipate changes to this privacy policy, we reserve the right 
 ### Contact Us
 If you have any questions about this privacy policy or the app, please contact Arran4 at:
 
-**Email:** proteincalc@arran4.com
+**Email:** [proteincalc@arran4.com](mailto:proteincalc@arran4.com)
 
 ---
 


### PR DESCRIPTION
## Summary
- link Protein to Weight Calculator privacy policy email address

## Testing
- `npm test` *(fails: Missing script: "test")*
- `hugo` *(fails: Module "github.com/hugo-toha/toha/v4" is not compatible with this Hugo version: Min 0.146.0 extended; ...)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf5b0b5c832f9956ecedffd0b41b