### PR TITLE
docs: note lack of analytics

### DIFF
--- a/content/privacy/arrans-movie-night-scheduler/index.md
+++ b/content/privacy/arrans-movie-night-scheduler/index.md
@@ -110,6 +110,10 @@ We may share Your personal information in the following situations:
 *   **With other users:** when You share personal information or otherwise interact in the public areas with other users, such information may be viewed by all users and may be publicly distributed outside.
 *   **With Your consent**: We may disclose Your personal information for any other purpose with Your consent.
 
+### Analytics
+
+We do not use analytics or tracking services. No usage data is collected for analytics purposes.
+
 ### Retention of Your Personal Data
 
 The Company will retain Your Personal Data only for as long as is necessary for the purposes set out in this Privacy Policy. We will retain and use Your Personal Data to the extent necessary to comply with our legal obligations (for example, if we are required to retain your data to comply with applicable laws), resolve disputes, and enforce our legal agreements and policies.

--- a/content/privacy/aurelies-dinners/index.md
+++ b/content/privacy/aurelies-dinners/index.md
@@ -15,6 +15,9 @@ Aurelie's Dinners: Random Meals does not collect, store, or share any personal i
 ## Data Collection
 The app does not use analytics, cookies, or third-party SDKs. Network access is only used when you choose to follow external links, such as the Google Play listing or recipe sites you add yourself.
 
+## Analytics
+This app does not perform any analytics or tracking.
+
 ## Third-Party Links
 Our application may link to external sites that are not operated by us. We have no control over the content and practices of these sites and cannot accept responsibility for their privacy policies.
 

--- a/content/privacy/cbz-viewer/index.md
+++ b/content/privacy/cbz-viewer/index.md
@@ -18,6 +18,9 @@ CBZ Viewer respects your privacy and is committed to protecting it. This privacy
 ## Data Collection
 CBZ Viewer does not collect, store, or transmit any personal data or usage information.
 
+## Analytics
+CBZ Viewer does not perform any analytics or tracking.
+
 ## Permissions
 The app may request permissions necessary to access your local storage for the purpose of reading and displaying CBZ files. These permissions are solely used for the app's functionality and do not involve data collection or sharing.
 

--- a/content/privacy/cook-times/index.md
+++ b/content/privacy/cook-times/index.md
@@ -20,6 +20,9 @@ The Cook Times App does **not collect, store, or share any personal data**. All 
 ## Internet and Network Usage
 The app does not require an internet connection to function and does not access any network resources. This ensures that your information stays private and secure.
 
+## Analytics
+The Cook Times App does not perform any analytics or tracking.
+
 ## Third-Party Services
 The Cook Times App does not integrate with any third-party services, analytics tools, or advertising platforms. As a result, no external entities receive any information about you or your usage of the app.
 

--- a/content/privacy/gizmo-card-creator/index.md
+++ b/content/privacy/gizmo-card-creator/index.md
@@ -27,6 +27,10 @@ Link to the privacy policy of third-party service providers used by the app:
 
 - [Google Play Services](https://www.google.com/policies/privacy/)
 
+## Analytics
+
+The app does not use any analytics or tracking services. No usage data is collected for analytics purposes.
+
 ## Log Data
 
 I want to inform you that whenever you use my Service, in a case of an error in the app I collect data and information (through third-party products) on your phone called Log Data. This Log Data may include information such as your device Internet Protocol ("IP") address, device name, operating system version, the configuration of the app when utilizing my Service, the time and date of your use of the Service, and other statistics.

--- a/content/privacy/lojban-messenger-dictionary/index.md
+++ b/content/privacy/lojban-messenger-dictionary/index.md
@@ -75,6 +75,10 @@ We do not collect or disclose Personal Data for any legal requirements.
 
 While we do not collect Personal Data, Facebook handles any data security measures.
 
+### Analytics
+
+We do not perform analytics or tracking. Any analytics data is managed by Facebook and not collected by this Service.
+
 ## Children's Privacy
 
 Our Service does not address anyone under the age of 13. We do not knowingly collect personally identifiable information from anyone. Any data concerning children is managed by Facebook.

--- a/content/privacy/protein-calculator/index.md
+++ b/content/privacy/protein-calculator/index.md
@@ -20,6 +20,9 @@ The Protein to Weight Calculator does **not collect, store, or share any persona
 ### Internet and Network Usage
 The app does not require an internet connection to function and does not access any network resources. This ensures that your information stays private and secure.
 
+### Analytics
+The app does not perform any analytics or tracking.
+
 ### Third-Party Services
 The Protein to Weight Calculator does not integrate with any third-party services, analytics tools, or advertising platforms. As a result, no external entities receive any information about you or your usage of the app.
 

--- a/content/privacy/rpg-gym-stats/index.md
+++ b/content/privacy/rpg-gym-stats/index.md
@@ -27,6 +27,10 @@ Link to the privacy policy of third-party service providers used by the app
 
 *   [Google Play Services](https://www.google.com/policies/privacy/)
 
+**Analytics**
+
+The app does not use analytics or tracking services.
+
 **Log Data**
 
 I want to inform you that whenever you use my Service, in a case of an error in the app I collect data and information (through third-party products) on your phone called Log Data. This Log Data may include information such as your device Internet Protocol (“IP”) address, device name, operating system version, the configuration of the app when utilizing my Service, the time and date of your use of the Service, and other statistics.


### PR DESCRIPTION
## Summary
- add Analytics sections to all privacy policies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `hugo --destination /tmp/hugo` *(fails: Module "github.com/hugo-toha/toha/v4" is not compatible with this Hugo version)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf5c9060832fb6473e59eb1e7727