### PR TITLE
Add effective date to RPG Gym Stats privacy policy

### DIFF
--- a/content/privacy/rpg-gym-stats/index.md
+++ b/content/privacy/rpg-gym-stats/index.md
@@ -9,6 +9,8 @@ url: /rpg-gym-stats/privacy/
 description: "Privacy policy for the RPG Gym Stats app."
 ---
 
+Effective Date: 2024-01-31
+
 Ubels Software Development built the RPG Gym Stats app as a Free app. This SERVICE is provided by Ubels Software Development at no cost and is intended for use as is.
 
 This page is used to inform visitors regarding my policies with the collection, use, and disclosure of Personal Information if anyone decided to use my Service.


### PR DESCRIPTION
## Summary
- add effective date line to the RPG Gym Stats privacy policy

## Testing
- `npm test` *(fails: Missing script "test")*
- `hugo` *(fails: can't evaluate field Sass in type interface)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf3a0e04832fb24bf2241b80babc