### PR TITLE
Fix navbar overlap on privacy pages

### DIFF
--- a/layouts/privacy/single.html
+++ b/layouts/privacy/single.html
@@ -9,7 +9,7 @@
 {{ define "sidebar" }}{{ end }}
 
 {{ define "content" }}
-<section class="content-section" id="content-section">
+<section class="content-section" id="content-section" style="padding-top: 80px;">
   <div class="content">
     <div class="container p-0 read-area">
       <div class="page-content">


### PR DESCRIPTION
## Summary
- prevent top navbar from obscuring privacy policy content

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_689ddc2689d0832fb010aef02b93780d