### PR TITLE
Confirm no analytics in privacy data collection sections

### DIFF
--- a/content/privacy/cbz-viewer/index.md
+++ b/content/privacy/cbz-viewer/index.md
@@ -16,7 +16,7 @@ description: "Privacy policy for the CBZ Viewer app."
 CBZ Viewer respects your privacy and is committed to protecting it. This privacy policy outlines how CBZ Viewer handles your data.
 
 ## Data Collection
-CBZ Viewer does not collect, store, or transmit any personal data or usage information.
+CBZ Viewer does not collect, store, or transmit any personal data or usage information. No analytics are used.
 
 ## Analytics
 CBZ Viewer does not perform any analytics or tracking.

--- a/content/privacy/cook-times/index.md
+++ b/content/privacy/cook-times/index.md
@@ -15,7 +15,7 @@ description: "Privacy policy for the Cook Times app."
 Thank you for using the **Cook Times App**. Your privacy is important to us, and we are committed to maintaining transparency about how your data is handled. This privacy policy explains that our app does not collect or share any personal information.
 
 ## Data Collection
-The Cook Times App does **not collect, store, or share any personal data**. All calculations performed within the app are executed locally on your device.
+The Cook Times App does **not collect, store, or share any personal data**. All calculations performed within the app are executed locally on your device. No analytics are used.
 
 ## Internet and Network Usage
 The app does not require an internet connection to function and does not access any network resources. This ensures that your information stays private and secure.

--- a/content/privacy/protein-calculator/index.md
+++ b/content/privacy/protein-calculator/index.md
@@ -15,7 +15,7 @@ description: "Privacy policy for the Protein to Weight Calculator app."
 Thank you for using the **Protein to Weight Calculator**. Arran4 ("we", "us", or "our") is the developer of this app. Your privacy is important to us, and we are committed to maintaining transparency about how your data is handled. This privacy policy explains that our app does not collect or share any personal information.
 
 ### Data Collection
-The Protein to Weight Calculator does **not collect, store, or share any personal data**. All calculations performed within the app are executed locally on your device.
+The Protein to Weight Calculator does **not collect, store, or share any personal data**. All calculations performed within the app are executed locally on your device. No analytics are used.
 
 ### Internet and Network Usage
 The app does not require an internet connection to function and does not access any network resources. This ensures that your information stays private and secure.


### PR DESCRIPTION
## Summary
- Clarify CBZ Viewer data collection section to state that no analytics are used
- Note in Cook Times data collection that the app uses no analytics
- Emphasize in Protein to Weight Calculator data collection that no analytics are used

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689de19e7e88832f9210f80df6d1ce6b