### PR TITLE
docs: add intro to protein calculator privacy page

### DIFF
--- a/content/privacy/protein-calculator/index.md
+++ b/content/privacy/protein-calculator/index.md
@@ -9,6 +9,8 @@ url: /protein-calculator/privacy/
 description: "Privacy policy for the Protein to Weight Calculator app."
 ---
 
+The Protein to Weight Calculator helps you estimate daily protein needs while keeping your data private. All calculations happen entirely on your device, and no personal information is collected or shared.
+
 **Effective Date:** 2024-12-17
 
 ### Introduction


### PR DESCRIPTION
## Summary
- add brief intro summarizing Protein to Weight Calculator’s purpose and privacy posture

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689de19709c8832fbf1f9ec291ca4c0c