### PR TITLE
Add effective date to Gizmo Card Creator privacy policy

### DIFF
--- a/content/privacy/gizmo-card-creator/index.md
+++ b/content/privacy/gizmo-card-creator/index.md
@@ -9,6 +9,8 @@ url: /gizmo-card-creator/privacy/
 description: "Privacy policy for the Gizmo Card Creator app."
 ---
 
+Effective Date: 2024-01-31
+
 Ubels Software Development built the Gizmo Card Creator app as a Free app. This SERVICE is provided by Ubels Software Development at no cost and is intended for use as is.
 
 This page is used to inform visitors regarding my policies with the collection, use, and disclosure of Personal Information if anyone decided to use my Service.


### PR DESCRIPTION
## Summary
- add an explicit effective date at the top of the Gizmo Card Creator privacy policy

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689de348277c832fa9a47c4c394a3c65