### PR TITLE
Add analytics section for RPG Gym Stats privacy page

### DIFF
--- a/content/privacy/rpg-gym-stats/index.md
+++ b/content/privacy/rpg-gym-stats/index.md
@@ -29,9 +29,9 @@ Link to the privacy policy of third-party service providers used by the app
 
 *   [Google Play Services](https://www.google.com/policies/privacy/)
 
-**Analytics**
+## Analytics
 
-The app does not use analytics or tracking services.
+The app does not use analytics or tracking services. No usage data is collected or tracked.
 
 **Log Data**
 


### PR DESCRIPTION
## Summary
- clarify RPG Gym Stats privacy page with an Analytics section stating no data is collected

## Testing
- `npm test` *(fails: Missing script "test")*
- `hugo --config hugo.yaml` *(fails: module theme requires newer Hugo version and build errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e698ff1ec832f98df79cd81cb1a2d