### PR TITLE
Add Third-Party Links section to Cook Times privacy policy

### DIFF
--- a/content/privacy/cook-times/index.md
+++ b/content/privacy/cook-times/index.md
@@ -26,6 +26,9 @@ The Cook Times App does not perform any analytics or tracking.
 ## Third-Party Services
 The Cook Times App does not integrate with any third-party services, analytics tools, or advertising platforms. As a result, no external entities receive any information about you or your usage of the app.
 
+## Third-Party Links
+The Cook Times App may contain links to external websites or resources. We are not responsible for the content or privacy practices of these third-party sites, which may have their own policies. We encourage you to review the privacy policies of any external resources you visit.
+
 ## Permissions
 The app does not request any permissions to access sensitive data or device features.
 


### PR DESCRIPTION
## Summary
- add third-party links section outlining responsibility for external sites

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `hugo` *(fails: can't evaluate field Sass in type interface {})*


------
https://chatgpt.com/codex/tasks/task_e_689e69eaec98832f996f52dc64b8ffa8