### PR TITLE
docs: mention Google Play developer in Aurelie's Dinners privacy policy

### DIFF
--- a/content/privacy/aurelies-dinners/index.md
+++ b/content/privacy/aurelies-dinners/index.md
@@ -10,7 +10,7 @@ description: "Privacy policy for Aurelie's Dinners: Random Meals."
 ---
 
 ## Introduction
-Aurelie's Dinners: Random Meals does not collect, store, or share any personal information. All meal data you enter stays on your device and is removed when the app is uninstalled.
+Aurelie's Dinners: Random Meals is developed and published on Google Play by Arran4. The app does not collect, store, or share any personal information. All meal data you enter stays on your device and is removed when the app is uninstalled.
 
 ## Data Collection
 The app does not use analytics, cookies, or third-party SDKs. Network access is only used when you choose to follow external links, such as the Google Play listing or recipe sites you add yourself.


### PR DESCRIPTION
## Summary
- clarify the legal developer entity for Aurelie's Dinners on Google Play

## Testing
- `hugo` *(fails: Module "github.com/hugo-toha/toha/v4" is not compatible with this Hugo version)*

------
https://chatgpt.com/codex/tasks/task_e_689e6a14ab38832fb7eece658feaa1c2