### PR TITLE
Fix github actions hugo build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -85,6 +85,8 @@ jobs:
           hugo mod npm pack
           npm install
           sudo rm -rf public
+          chmod -R u+w ~/.cache/hugo_cache/ || true
+          chmod -R u+w $(go env GOPATH)/pkg/mod/ || true
           hugo --minify --templateMetrics
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -85,8 +85,8 @@ jobs:
           hugo mod npm pack
           npm install
           sudo rm -rf public
-          chmod -R u+w ~/.cache/hugo_cache/ || true
-          chmod -R u+w $(go env GOPATH)/pkg/mod/ || true
+          sudo chmod -R u+w /home/runner/.cache/hugo_cache/ || true
+          sudo chmod -R u+w /home/runner/go/pkg/mod/ || true
           hugo --minify --templateMetrics
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,6 +29,7 @@ jobs:
           extended: true
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
 
       - name: Cache stars data
         id: cache-stars
@@ -85,8 +86,8 @@ jobs:
           hugo mod npm pack
           npm install
           sudo rm -rf public
-          sudo chmod -R u+w /home/runner/.cache/hugo_cache/ || true
-          sudo chmod -R u+w /home/runner/go/pkg/mod/ || true
+          chmod -R u+w ${{ runner.temp }}/hugo_cache || true
+          chmod -R u+w $(go env GOPATH)/pkg/mod/ || true
           hugo --minify --templateMetrics
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "arran4.github.io",
       "version": "0.1.0",
-      "dependencies": {
-        "@popperjs/core": "^2.11.8"
-      },
       "devDependencies": {
         "@fontsource/mulish": "5.2.8",
         "@fortawesome/fontawesome-free": "^7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "arran4.github.io",
       "version": "0.1.0",
+      "dependencies": {
+        "@popperjs/core": "^2.11.8"
+      },
       "devDependencies": {
         "@fontsource/mulish": "5.2.8",
         "@fortawesome/fontawesome-free": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
   "comments": {
-    "dependencies": {
-      "@popperjs/core": "^2.11.8"
-    },
     "devDependencies": {
       "@fontsource/mulish": "github.com/hugo-toha/toha/v4",
       "@fortawesome/fontawesome-free": "github.com/hugo-toha/toha/v4",
@@ -29,11 +26,9 @@
       "popper.js": "github.com/hugo-toha/toha/v4",
       "postcss": "github.com/hugo-toha/toha/v4",
       "postcss-cli": "github.com/hugo-toha/toha/v4",
-      "typeit": "github.com/hugo-toha/toha/v4"
+      "typeit": "github.com/hugo-toha/toha/v4",
+      "@popperjs/core": "github.com/hugo-toha/toha/v4"
     }
-  },
-  "dependencies": {
-    "@popperjs/core": "^2.11.8"
   },
   "devDependencies": {
     "@fontsource/mulish": "5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "comments": {
-    "dependencies": {},
+    "dependencies": {
+      "@popperjs/core": "^2.11.8"
+    },
     "devDependencies": {
       "@fontsource/mulish": "github.com/hugo-toha/toha/v4",
       "@fortawesome/fontawesome-free": "github.com/hugo-toha/toha/v4",
@@ -29,6 +31,9 @@
       "postcss-cli": "github.com/hugo-toha/toha/v4",
       "typeit": "github.com/hugo-toha/toha/v4"
     }
+  },
+  "dependencies": {
+    "@popperjs/core": "^2.11.8"
   },
   "devDependencies": {
     "@fontsource/mulish": "5.2.8",


### PR DESCRIPTION
Fixes the GitHub Actions build failures for Hugo. The build was failing due to a missing dependency (`@popperjs/core`) and a permission denied error when attempting to copy and overwrite a read-only `sitemap.xml` file sourced from the theme's module cache.

---
*PR created automatically by Jules for task [653895702933750697](https://jules.google.com/task/653895702933750697) started by @arran4*