### PR TITLE
Redo PR 70

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -49,11 +49,11 @@ jobs:
           STARS_FILE="data/stars.json"
           echo "{}" > "$STARS_FILE"
 
-          for repo_url in $(yq e '.projects[].repo' data/en/sections/projects.yaml); do
+          for repo_url in $(yq '.projects[].repo' data/en/sections/projects.yaml | tr -d '"'); do
             if [[ "$repo_url" == "null" ]]; then
               continue
             fi
-            repo_path=$(echo "$repo_url" | sed 's/https://github.com\///')
+            repo_path=$(echo "$repo_url" | sed 's|https://github.com/||')
 
             stars=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$repo_path" | jq '.stargazers_count')
 
@@ -83,8 +83,9 @@ jobs:
         if: ${{ steps.diff_check.outputs.changed == 'true' || github.event_name == 'pull_request' }}
         run: |
           hugo mod npm pack
-          npm install
-          sudo rm -rf public
+          npm install @popperjs/core@2.11.8 include-media@1.4.10 --save-dev --legacy-peer-deps
+          npm install --legacy-peer-deps
+          sudo rm -rf public/
           hugo --minify --templateMetrics
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # arran4.github.io
 
+* [Blog](https://arran4.github.io/blog/)
+
 ## License
 
 This content is licensed under the [Creative Commons Attribution 4.0 International License](LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "fuse.js": "^7.1.0",
         "highlight.js": "^11.11.1",
         "imagesloaded": "^5.0.0",
-        "include-media": "^2.0.0",
+        "include-media": "^1.4.10",
         "katex": "^0.16.33",
         "lodash-es": "^4.18.1",
         "mark.js": "^8.11.1",
@@ -3325,9 +3325,9 @@
       }
     },
     "node_modules/include-media": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/include-media/-/include-media-2.0.0.tgz",
-      "integrity": "sha512-LSJcffPYIZ/Kln0rIi5UhqQbZxElDCMYA4dPC5MI1rkwwjptgEiOicHnzB0MMhMNJver0+4zULb4MKlgDyapZg==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/include-media/-/include-media-1.4.10.tgz",
+      "integrity": "sha512-TymQzKF7oWHbItEcEHOCponZ90lRr1I9QbYeD+qCxXy4Z0/pSpS4Ocz2bq3FMOERlXXrY9Sawsh9GjiObVQA6A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "fuse.js": "^7.1.0",
     "highlight.js": "^11.11.1",
     "imagesloaded": "^5.0.0",
-    "include-media": "^2.0.0",
+    "include-media": "^1.4.10",
     "katex": "^0.16.33",
     "lodash-es": "^4.18.1",
     "mark.js": "^8.11.1",


### PR DESCRIPTION
This PR re-applies changes from PR 70, which included:
- Updates `.github/workflows/gh-pages.yml` with fixes to `yq` and `npm install` actions.
- Updates `README.md` to include a link to the Blog.
- Updates dependencies `include-media` to `1.4.10` and `@popperjs/core` to `2.11.8`.

---
*PR created automatically by Jules for task [13165971770809438905](https://jules.google.com/task/13165971770809438905) started by @arran4*