### PR TITLE
Fix GitHub Actions Hugo Permission Error

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -82,10 +82,13 @@ jobs:
       - name: Everything required
         if: ${{ steps.diff_check.outputs.changed == 'true' || github.event_name == 'pull_request' }}
         run: |
+          export HUGO_CACHEDIR=${{ runner.temp }}/hugo_cache
+          mkdir -p ${{ runner.temp }}/hugo_cache
           hugo mod npm pack
           npm install @popperjs/core@2.11.8 include-media@1.4.10 --save-dev --legacy-peer-deps
           npm install --legacy-peer-deps
           sudo rm -rf public/
+          chmod -R u+w ${{ runner.temp }}/hugo_cache
           hugo --minify --templateMetrics
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes build failure where Hugo failed to overwrite read-only files from the module cache. This correctly scopes `HUGO_CACHEDIR` to a temp directory and uses `chmod -R u+w` to ensure it is writable.

---
*PR created automatically by Jules for task [2749357011983651332](https://jules.google.com/task/2749357011983651332) started by @arran4*