### PR TITLE
ci: explicitly define HUGO_CACHEDIR and make writable

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -86,6 +86,9 @@ jobs:
           npm install @popperjs/core@2.11.8 include-media@1.4.10 --save-dev --legacy-peer-deps
           npm install --legacy-peer-deps
           sudo rm -rf public/
+          export HUGO_CACHEDIR=${{ runner.temp }}/hugo_cache
+          mkdir -p $HUGO_CACHEDIR
+          chmod -R u+w $HUGO_CACHEDIR
           hugo --minify --templateMetrics
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes a permission denied error during Hugo module operations in GitHub Actions CI by setting `HUGO_CACHEDIR` to a runner-temporary path, creating it, and applying write permissions before the `hugo --minify` build step.

---
*PR created automatically by Jules for task [16717315358983441094](https://jules.google.com/task/16717315358983441094) started by @arran4*