### PR TITLE
Switch to GitHub Pages Action deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,7 +1,12 @@
 name: GitHub Pages
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 on:
   push:
@@ -12,10 +17,10 @@ on:
     - cron: '5 0 * * *'
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+    outputs:
+      changed: ${{ steps.diff_check.outputs.changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -79,6 +84,9 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Everything required
         if: ${{ steps.diff_check.outputs.changed == 'true' || github.event_name == 'pull_request' }}
         run: |
@@ -95,10 +103,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         if: ${{ github.ref == 'refs/heads/main' && (steps.diff_check.outputs.changed == 'true' || github.event_name == 'pull_request') }}
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
-          force_orphan: true
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.ref == 'refs/heads/main' && (needs.build.outputs.changed == 'true' || github.event_name == 'pull_request') }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Replaced the legacy `peaceiris/actions-gh-pages` branch deployment method with the modern `actions/upload-pages-artifact` and `actions/deploy-pages` actions. Updated workflow permissions, restructured jobs into `build` and `deploy` per best practice, and validated changes with `actionlint`.

---
*PR created automatically by Jules for task [3649508294379764075](https://jules.google.com/task/3649508294379764075) started by @arran4*